### PR TITLE
Fix ECDSA algorithm failure and reduce overhead caused by access token size #1

### DIFF
--- a/Environment/ECDSA.cs
+++ b/Environment/ECDSA.cs
@@ -61,7 +61,7 @@ namespace TrustGuard.Environment
 			for(int i = 0; i < 32; i++)
 			{
 				result[i + 32] = i < sb.Length ? sb[i] : (byte)0;
-				result[i] = rb[i];
+				result[i] = i < rb.Length ? rb[i] : (byte)0;
 			}
 
 			return result;

--- a/Environment/TokenFactory.cs
+++ b/Environment/TokenFactory.cs
@@ -46,7 +46,6 @@ namespace TrustGuard.Environment
 
 			identity.AddClaim(ClaimType.Audience, tokenDescription.Audience);
 			identity.AddClaim(ClaimType.Expires, GetUnixTime(DateTime.UtcNow.AddMinutes(5)).ToString());
-			identity.AddClaim(ClaimType.Jti, Guid.NewGuid().ToString());
 
 			string header = GetHeader();
 			string payload = identity.GetPayload();


### PR DESCRIPTION
Fix ECDSA algorithm failure and reduce overhead caused by access token size.